### PR TITLE
Started JSON book store catalog

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,0 +1,25 @@
+{
+  "products": [
+    {
+      "title": "The Uncertainty Principle – Issue 4: Reality",
+      "type": "Zine",
+      "blurb": "An experimental zine exploring learning, reality, and uncertainty.",
+      "url": "https://store.teachinglaboratory.com/l/theup-issue4",
+      "price": "Pay what you want (min $5)"
+    },
+    {
+      "title": "Peeragogy Handbook (3.0 Edition)",
+      "type": "Handbook",
+      "blurb": "A collaboratively written guide to peer learning and peer production.",
+      "url": "https://store.teachinglaboratory.com/l/peeragogy3",
+      "price": "Pay what you want (min $10)"
+    },
+    {
+      "title": "ENG 099 Conversational American English Textbook",
+      "type": "Textbook",
+      "blurb": "A resource for ESL learners with patterns, dialogues, and activities.",
+      "url": "https://store.teachinglaboratory.com/l/eng099",
+      "price": "$15"
+    }
+  ]
+}


### PR DESCRIPTION
Recommended by ChatGPT 5

"Perfect, Iceman — here’s the simpler version: instead of connecting Google Sheets + API keys, you just keep a static JSON file with your catalog (e.g., catalog.json) and host it somewhere public (GitHub Pages, mr.danoff.org, or even Gumroad if it supports it).

1. Example JSON Catalog

Save this as catalog.json:

{
  "products": [
    {
      "title": "The Uncertainty Principle – Issue 4: Reality",
      "type": "Zine",
      "blurb": "An experimental zine exploring learning, reality, and uncertainty.",
      "url": "https://store.teachinglaboratory.com/l/theup-issue4",
      "price": "Pay what you want (min $5)"
    },
    {
      "title": "Peeragogy Handbook (3.0 Edition)",
      "type": "Handbook",
      "blurb": "A collaboratively written guide to peer learning and peer production.",
      "url": "https://store.teachinglaboratory.com/l/peeragogy3",
      "price": "Pay what you want (min $10)"
    },
    {
      "title": "ENG 099 Conversational American English Textbook",
      "type": "Textbook",
      "blurb": "A resource for ESL learners with patterns, dialogues, and activities.",
      "url": "https://store.teachinglaboratory.com/l/eng099",
      "price": "$15"
    }
  ]
}


You can expand this anytime with new zines, papers, or bundles."